### PR TITLE
Gem translation namespacing

### DIFF
--- a/app/controllers/spree/admin/customer_images_controller.rb
+++ b/app/controllers/spree/admin/customer_images_controller.rb
@@ -13,13 +13,13 @@ module Spree
 
       def approve
         @customer_image.approve
-        flash[:success] = I18n.t('spree.info_approve_customer_image')
+        flash[:success] = I18n.t('spree.customer_images.info_approve')
         redirect_to admin_customer_images_path
       end
 
       def reject
         @customer_image.reject
-        flash[:success] = I18n.t('spree.info_reject_customer_image')
+        flash[:success] = I18n.t('spree.customer_images.info_reject')
         redirect_to admin_customer_images_path
       end
     end

--- a/app/controllers/spree/customer_images_controller.rb
+++ b/app/controllers/spree/customer_images_controller.rb
@@ -11,7 +11,7 @@ module Spree
     def create
       @customer_image = Spree::CustomerImage.new(review_params)
       if @customer_image.save
-        flash[:success] = I18n.t('spree.customer_image_successfully_submitted')
+        flash[:success] = I18n.t('spree.customer_images.successfully_submitted')
         redirect_to spree.product_path(@product)
       else
         render :new

--- a/app/overrides/add_customer_images_tab_to_admin.rb
+++ b/app/overrides/add_customer_images_tab_to_admin.rb
@@ -8,5 +8,5 @@ Deface::Override.new(
   virtual_path: "spree/admin/shared/_product_sub_menu",
   name: "customer_images_admin_tab",
   insert_bottom: "[data-hook='admin_product_sub_tabs']",
-  text: "<%= tab(:customer_images, label: 'customer_images_management') %>"
+  text: "<%= tab(:customer_images, label: 'customer_images.management') %>"
 )

--- a/app/views/spree/admin/customer_images/edit.html.erb
+++ b/app/views/spree/admin/customer_images/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= t('spree.editing_customer_image', link: link_to(@customer_image.product.name, product_path(@customer_image.product))) %>
+  <%= t('spree.customer_images.editing', link: link_to(@customer_image.product.name, product_path(@customer_image.product))) %>
 <% end %>
 
 <% render 'spree/admin/shared/product_sub_menu' %>

--- a/app/views/spree/admin/customer_images/index.html.erb
+++ b/app/views/spree/admin/customer_images/index.html.erb
@@ -1,7 +1,7 @@
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Product), spree.admin_products_path) %>
 
 <% content_for :page_title do %>
-  <%= t('spree.customer_images') %>
+  <%= t('spree.customer_images.customer_images') %>
 <% end %>
 
 <% content_for :table_filter_title do %>
@@ -11,7 +11,7 @@
 <% content_for :table_filter do %>
   <%= form_for url_for, method: :get do %>
     <div class="fourteen columns">
-      <%= label_tag nil, t('spree.search_by_sku') %>
+      <%= label_tag nil, t('spree.customer_images.search_by_sku') %>
       <%= text_field_tag :sku %>
       <%= button t('spree.search'), 'icon-search' %>
     </div>
@@ -24,8 +24,8 @@
           <%= f.label :approved_eq, t('spree.approval_status')-%><br/>
           <%= f.select :approved_eq, [
               [t('spree.all'), nil],
-              [t('spree.approved_customer_images'), true],
-              [t('spree.rejected_customer_images'), false]
+              [t('spree.customer_images.approved'), true],
+              [t('spree.customer_images.rejected'), false]
             ], {}, class: 'select2 fullwidth'  -%>
         </div>
       </div>

--- a/app/views/spree/customer_images/new.html.erb
+++ b/app/views/spree/customer_images/new.html.erb
@@ -1,6 +1,6 @@
-<%= content_tag :h2, t('spree.add_customer_image_for', name: @product.name), class: 'new-customer-image__title' %>
+<%= content_tag :h2, t('spree.customer_images.add_for', name: @product.name), class: 'new-customer-image__title' %>
 
-<p><%= t 'spree.moderation_message' %></p>
+<p><%= t 'spree.customer_images.moderation_message' %></p>
 
 <%= form_for @customer_image, url: product_customer_images_path(@product) do |f| %>
   <%= render "spree/shared/error_messages", target: @customer_image %>
@@ -28,6 +28,6 @@
   </p>
 
   <p class="new-customer-image__submit">
-    <%= f.submit t('spree.submit_customer_image'), class: "button bg_darkfirst" %>
+    <%= f.submit t('spree.customer_images.submit'), class: "button bg_darkfirst" %>
   </p>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,21 +13,23 @@ en:
         other: Customer images
 
   spree:
-    customer_images: Customer images
-    approval_status: Approval status
-    approve: Approve
-    reject: Reject
-    pending: Pending
-    approved: Approved
-    rejected: Rejected
-    submit_customer_image: Submit picture
-    add_customer_image_for: Add customer image for %{name}
-    customer_image_successfully_submitted: Customer image was successfully submitted
-    info_approve_customer_image: Customer image was successfully approved
-    info_reject_customer_image: Customer image was successfully rejected
-    editing_customer_image: Editing customer image
-    moderation_message: Your picture will be reviewed before publication.
-    search_by_sku: Search by SKU
+    customer_images:
+      customer_images: Customer images
+      approval_status: Approval status
+      approve: Approve
+      reject: Reject
+      pending: Pending
+      approved: Approved
+      rejected: Rejected
+      submit: Submit picture
+      add_for: Add customer image for %{name}
+      successfully_submitted: Customer image was successfully submitted
+      info_approve: Customer image was successfully approved
+      info_reject: Customer image was successfully rejected
+      editing: Editing customer image
+      moderation_message: Your picture will be reviewed before publication.
+      search_by_sku: Search by SKU
     admin:
       tab:
-        customer_images_management: Customer images
+        customer_images:
+          management: Customer images

--- a/spec/controllers/spree/admin/customer_images_controller_spec.rb
+++ b/spec/controllers/spree/admin/customer_images_controller_spec.rb
@@ -29,7 +29,7 @@ module Spree
 
           it 'shows a message when approved' do
             expect(response).to redirect_to spree.admin_customer_images_path
-            expect(flash[:success]).to eq I18n.t('spree.info_approve_customer_image')
+            expect(flash[:success]).to eq I18n.t('spree.customer_images.info_approve')
           end
         end
 
@@ -38,7 +38,7 @@ module Spree
 
           it 'shows a message when rejected' do
             expect(response).to redirect_to spree.admin_customer_images_path
-            expect(flash[:success]).to eq I18n.t('spree.info_reject_customer_image')
+            expect(flash[:success]).to eq I18n.t('spree.customer_images.info_reject')
           end
         end
       end

--- a/spec/controllers/spree/customer_images_controller_spec.rb
+++ b/spec/controllers/spree/customer_images_controller_spec.rb
@@ -52,7 +52,7 @@ module Spree
 
       it 'flashes the notice' do
         post :create, params: customer_image_params
-        expect(flash[:success]).to eq I18n.t('spree.customer_image_successfully_submitted')
+        expect(flash[:success]).to eq I18n.t('spree.customer_images.successfully_submitted')
       end
 
       it 'redirects to product page' do


### PR DESCRIPTION
In order to better separate this gem translations all the keys have been
moved under `customer_images` namespace.