### PR TITLE
Allow CustomerImage#image association class customization

### DIFF
--- a/app/models/spree/customer_image.rb
+++ b/app/models/spree/customer_image.rb
@@ -8,7 +8,7 @@ module Spree
 
     belongs_to :product, class_name: 'Spree::Product', inverse_of: :customer_images, foreign_key: :spree_product_id, touch: true
     belongs_to :user, class_name: Spree.user_class.name, inverse_of: :customer_images, foreign_key: :spree_user_id, touch: true
-    has_one :image, class_name: 'Spree::Image', as: :viewable, dependent: :destroy
+    has_one :image, class_name: SolidusCustomerImages::Config.image_class_name, as: :viewable, dependent: :destroy
 
     scope :approved, -> { where approved: true }
     scope :rejected, -> { where approved: false }

--- a/app/models/spree/customer_images_configuration.rb
+++ b/app/models/spree/customer_images_configuration.rb
@@ -1,0 +1,5 @@
+module Spree
+  class CustomerImagesConfiguration < Preferences::Configuration
+    preference :image_class_name, :string, default: 'Spree::Image'
+  end
+end

--- a/lib/solidus_customer_images/engine.rb
+++ b/lib/solidus_customer_images/engine.rb
@@ -9,6 +9,10 @@ module SolidusCustomerImages
       g.test_framework :rspec
     end
 
+    initializer 'spree.customer_images.environment', before: :load_config_initializers do
+      SolidusCustomerImages::Config = Spree::CustomerImagesConfiguration.new
+    end
+
     def self.activate
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)

--- a/spec/models/spree/customer_image_spec.rb
+++ b/spec/models/spree/customer_image_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Spree::CustomerImage, type: :model do
     expect(described_class.new.image).to be_present
   end
 
+  it 'builds associated image of the expected class' do
+    klass = SolidusCustomerImages::Config.image_class_name.constantize
+    expect(described_class.new.image.class).to be klass
+  end
+
   context 'when initializing a record' do
     let(:user) { Spree.user_class.new(email: 'foo@bar.com') }
     let(:email) { 'test@example.com' }


### PR DESCRIPTION
The model class of the `#image` association can now be easily customized by
changing the class attribute `Spree::CustomerImage.image_class_name`.