### PR TITLE
Rename params methods

### DIFF
--- a/app/controllers/spree/customer_images_controller.rb
+++ b/app/controllers/spree/customer_images_controller.rb
@@ -6,11 +6,11 @@ module Spree
 
     def new
       @title = I18n.t('spree.customer_images.new_image_page_title', name: @product.name)
-      @customer_image = Spree::CustomerImage.new(base_review_params)
+      @customer_image = Spree::CustomerImage.new(base_customer_image_params)
     end
 
     def create
-      @customer_image = Spree::CustomerImage.new(review_params)
+      @customer_image = Spree::CustomerImage.new(customer_image_params)
       if @customer_image.save
         flash[:success] = I18n.t('spree.customer_images.successfully_submitted')
         redirect_to spree.product_path(@product)
@@ -25,13 +25,13 @@ module Spree
       @product = Spree::Product.friendly.find(params[:product_id])
     end
 
-    def base_review_params
+    def base_customer_image_params
       { user: try_spree_current_user, product: @product }
     end
 
-    def review_params
+    def customer_image_params
       permitted = [:user_name, :email, :description, image_attributes: [:attachment]]
-      params.require(:customer_image).permit(permitted).merge(base_review_params)
+      params.require(:customer_image).permit(permitted).merge(base_customer_image_params)
     end
   end
 end


### PR DESCRIPTION
Some private controller methods are renamed in order to properly match the
model domain.